### PR TITLE
feat: SLL 재발급 자동화를 위해 Dockerfile의 SSL 파일 매핑 경로를 변경

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 .env.*
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,10 @@ ENV APACHE_DOCUMENT_ROOT=/var/www/html/public
 RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf
 RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
 
-RUN sed -i '/SSLCertificateFile.*snakeoil\.pem/c\SSLCertificateFile /etc/letsencrypt/live/every-discussion.com/fullchain.pem' /etc/apache2/sites-available/default-ssl.conf
-RUN sed -i '/SSLCertificateKeyFile.*snakeoil\.key/c\SSLCertificateKeyFile /etc/letsencrypt/live/every-discussion.com/privkey.pem' /etc/apache2/sites-available/default-ssl.conf
+# ssl 변경
+RUN sed -i '/SSLCertificateFile.*snakeoil\.pem/c\SSLCertificateFile /etc/letsencrypt/live/www.every-discussion.com/fullchain.pem' /etc/apache2/sites-available/default-ssl.conf
+RUN sed -i '/SSLCertificateKeyFile.*snakeoil\.key/c\SSLCertificateKeyFile /etc/letsencrypt/live/www.every-discussion.com/privkey.pem' /etc/apache2/sites-available/default-ssl.conf
+
 RUN a2ensite default-ssl
 
 WORKDIR /var/www/html/public

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,6 @@ services:
     ports:
       - "0.0.0.0:${VITE_APP_PORT_SSL}:443"
     volumes:
-      - ./ssl:/etc/letsencrypt/live/every-discussion.com/
+      - ./docker/letsencrypt:/etc/letsencrypt
     command: sh -c "apachectl -D FOREGROUND"
     restart: always


### PR DESCRIPTION
#66 SSL 재발급을 위해 SLL 파일 매핑 경로 변경. 실제 SSL 파일은 백엔드와 공유하여 rsync로 처리한다.